### PR TITLE
Intelligently search for call cached outputs in option B mode

### DIFF
--- a/pyoink.py
+++ b/pyoink.py
@@ -74,14 +74,14 @@ option_b = parser.add_argument_group("""\n
                                     If 5 files fail #2, then those 5 failures will move on to #3.
                                     
                                     It's simple! (Kind of.)""")
-option_b.add_argument('--bucket', default="fc-caa84e5a-8ef7-434e-af9c-feaf6366a042", help="workspace bucket")
+option_b.add_argument('--bucket', default="fc-d11c2e78-5175-400e-b517-6b070fad43b6", help="workspace bucket")
 option_b.add_argument('--submission_id', help="submission ID as it appears in Terra")
 option_b.add_argument('--workflow_name', default="myco", help="""name of workflow as it appears in the WDL
                                                     on the line that starts with 'workflow'. this
                                                     name might not match Dockstore name or filename
                                                     of the WDL.""")
 option_b.add_argument('--workflow_id', help="ID of workflow as it appears in Terra")
-option_b.add_argument('--task', default="make_mask_and_diff", help="name of WDL task")
+option_b.add_argument('--task', default="make_mask_and_diff_no_covstats", help="name of WDL task")
 option_b.add_argument('--file', default="*.diff", help="filename (wildcards and subfolders below the workdir are supported, e.g. outputs/*.bam)")
 
 option_b.add_argument('--not_scattered', action="store_true", help="outputs are not from a scattered task (skips running gsutil ls)")
@@ -143,7 +143,7 @@ def determine_what_downloaded(stderr_as_multi_line_string, exceptions_file):
     probable_successes = []
     for line in (stderr_as_multi_line_string.splitlines()):
         if line.startswith("CommandException"):
-            if verbose: print(f"gsutil reported {line}")
+            if veryverbose: print(f"gsutil reported {line}")
             gs = grab_gs_address(line)
             if gs is not None:
                 exceptions.append(gs)
@@ -167,6 +167,26 @@ def determine_what_downloaded(stderr_as_multi_line_string, exceptions_file):
         f.writelines(f"{uri}\n" for uri in list(known_successes_set))
     return [list(known_successes_set), exceptions]
 
+def indent(depth, batch):
+    return f"{fill_with('    ', depth)}{fill_with('+', batch)}"
+
+def fill_with(char, number):
+    '''goofy indentation-for-prints thingy'''
+    soon_to_be_string = []
+    for i in range(0, number):
+        soon_to_be_string.append(char)
+    return "".join(soon_to_be_string)
+
+def debug_count_lines(some_file, notes):
+    '''debug function that counts lines in a file and prints other info'''
+    try:
+        with open(some_file, 'r') as some_file_handler:
+            contents = some_file_handler.readlines()
+            print(f'{some_file}: {len(contents)} lines -- {notes}')
+            print(f'first line: {contents[0]}')
+    except FileNotFoundError:
+        print(f"Tried to read {some_file} w/ circumstances {notes} but file wasn't found")
+
 def parse_gsutil_stderr(stderr_file):
     with open(stderr_file) as f:
         list_of_lines = f.readlines()
@@ -189,70 +209,88 @@ def read_jm_file(thingy):
     gs_addresses_flat = [uri for line_of_uris in gs_addresses for uri in line_of_uris]
     return gs_addresses_flat
 
-def retrieve_data(gs_addresses: list):
+def retrieve_data(gs_addresses: list, depth=0, batch=0):
     ''' Actually pull gs:// addresses, after checking it's not too many at a time. This function
     is recursive if a lot of files need to be downloaded.'''
     uris_as_string = " ".join(gs_addresses)
+
+    if verbose: print(f"{indent(depth,batch)}Processing {len(gs_addresses)} gs_addresses")
 
     # first check for gsutil's 1000 argument limit (checks LIST length, not string length)
     if len(gs_addresses) > 998:
         if verbose: print("Approaching gsutil's limit on number of arguments, splitting into smaller batches...")
         list_of_smallish_lists_of_uris = [gs_addresses[i:i + 499] for i in range(0, len(gs_addresses), 499)]
+        batch = 0
         for smallish_list_of_uris in list_of_smallish_lists_of_uris:
-            #if verbose: print(f"Downloading this subset:\n {smallish_list_of_uris}")
-            retrieve_data(smallish_list_of_uris)
+            batch += 1
+            if verbose: print(f"{fill_with('    ', depth)}{fill_with('+', batch)}Batch {batch} out of {len(list_of_smallish_lists_of_uris)}:")
+            if veryverbose: print(f"Downloading this subset:\n {smallish_list_of_uris}")
+            retrieve_data(smallish_list_of_uris, depth=depth+1, batch=batch)
     
     # now check for the debugging small_steps argument (checks LIST length, not string length)
-    if len(gs_addresses) > 50 and args.small_steps is True:
+    elif len(gs_addresses) > 50 and args.small_steps is True:
         if verbose: print("small-steps was passed in, so we'll be downloading only 50 files at a time...")
         list_of_smallish_lists_of_uris = [gs_addresses[i:i + 50] for i in range(0, len(gs_addresses), 50)]
+        batch = 0
         for smallish_list_of_uris in list_of_smallish_lists_of_uris:
-            #if verbose: print(f"Downloading this subset:\n {smallish_list_of_uris}")
-            retrieve_data(smallish_list_of_uris)
+            batch += 1
+            if verbose: print(f"{fill_with('    ', depth)}{fill_with('+', batch)}Batch {batch} out of {len(list_of_smallish_lists_of_uris)}:")
+            if veryverbose: print(f"Downloading this subset:\n {smallish_list_of_uris}")
+            retrieve_data(smallish_list_of_uris, depth=depth+1, batch=batch)
     
     # then check for MAX_ARG_STRLEN (checks STRING length, not list length)
     elif len(uris_as_string) > 131000: # MAX_ARG_STRLEN minus 72
         if verbose: print("Approaching MAX_ARG_STRLEN, splitting into smaller batches...")
         list_of_smallish_lists_of_uris = [download_me[i:i + 499] for i in range(0, len(download_me), 499)]
+        batch = 0
         for smallish_list_of_uris in list_of_smallish_lists_of_uris:
-            #if verbose: print(f"Downloading this subset:\n {smallish_list_of_uris}")
-            retrieve_data(smallish_list_of_uris)
+            batch += 1
+            if verbose: print(f"{fill_with('    ', depth)}{fill_with('+', batch)}Batch {batch} out of {len(list_of_smallish_lists_of_uris)}:")
+            if veryverbose: print(f"Downloading this subset:\n {smallish_list_of_uris}")
+            retrieve_data(smallish_list_of_uris, depth=depth+1, batch=batch)
    
     # iff all checks pass, actually download (we do this in an else block to avoid downloading twice when recursing) 
     else:
         command = f"gsutil -m cp {uris_as_string} {od}"
-        if verbose:
-            print(f"Attempting to download {len(gs_addresses)} files via the following command:\n {command}\n\n")
+        if veryverbose:
+            print(f"{fill_with('    ', depth)}{fill_with('+', batch)}Attempting to download {len(gs_addresses)} files via the following command:\n {command}\n\n")
         else:
-            print(f"Downloading {len(gs_addresses)} files, please wait...")
+            print(f"{fill_with('    ', depth)}{fill_with('+', batch)}Downloading {len(gs_addresses)} files, please wait...")
         this_download = subprocess.run(f'gsutil -m cp {uris_as_string} {od}', shell=True, capture_output=True, encoding="UTF-8")
         # for some reason gsutil puts everything in stderr and nothing in stdout, so we have to do a lot of parsing to find CommandExceptions
         # todo: we could do even more parsing and subprocess.check_call to maybe get gsutil's progress bars!
         # see: https://stackoverflow.com/questions/33028298/prevent-string-being-printed-python
+        if veryverbose: debug_count_lines("gsutil.stderr", "just before overwrite in the big else")
 
         # write gsutil stderr to a file, so we can parse it when recursing
         with open("gsutil.stderr", "w") as f:
             for line in this_download.stderr:
                 f.write(line)
+        if veryverbose: debug_count_lines("gsutil.stderr", "just after overwrite in the big else")
 
         # we don't need to parse the file we just wrote here since we still have this_download.stderr in memory
         successes_and_exceptions = determine_what_downloaded(this_download.stderr, exceptions_file=args.exceptions_file)
         successes = successes_and_exceptions[0]
         exceptions = successes_and_exceptions[1]
         global_successes.append(successes)
-        print(f"Attempted {len(gs_addresses)} downloads: {len(successes)} succeeded, {len(exceptions)} failed, gsutil returned {this_download.returncode}.")
+        print(f"{fill_with('    ', depth)}{fill_with('+', batch)}Attempted {len(gs_addresses)} downloads: {len(successes)} succeeded, {len(exceptions)} failed, gsutil returned {this_download.returncode}.")
 
         # check for attempt-2/ if any downloads failed
         if len(exceptions) > 0 and args.job_manager_arrays_file != "attempt2.tmp" and not args.do_not_attempt2_on_failure:
-            print(f"Looking for {len(exceptions)} files in attempt-2/ folders...")
-            with open("attempt2.tmp", "a") as f:
+            print(f"{fill_with('    ', depth)}{fill_with('+', batch)}Looking for {len(exceptions)} files in attempt-2/ folders...")
+            if veryverbose: debug_count_lines("attempt2.tmp", "just before overwrite")
+
+            with open("attempt2.tmp", "w") as f:
                 for failed_gs_uri in exceptions:
                     possible_output_after_preempting = failed_gs_uri.removesuffix(args.file) + "attempt-2/" + args.file + "\n"
                     f.write(possible_output_after_preempting)
+            if veryverbose: debug_count_lines("attempt2.tmp", "just after overwrite")
+            
             # this call mixes a group A and a group B input variable -- but we'll allow that because it helps stop us from recursing infinitely
-            with subprocess.Popen(f'python3 pyoink.py -f "attempt-2-exceptions.txt" --job_manager_arrays_file "attempt2.tmp"', shell=True, stdout=subprocess.PIPE, stderr=subprocess.STDOUT) as recurse:
+            with subprocess.Popen(f'python3 pyoink.py -f "attempt-2-exceptions.txt" --job_manager_arrays_file "attempt2.tmp" --do_not_attempt2_on_failure', shell=True, stdout=subprocess.PIPE, stderr=subprocess.STDOUT) as recurse:
                 for output in recurse.stdout:
-                    print(f'-p->{output.decode("UTF-8")}')
+                    print(f'{fill_with("    ", depth+1)}{fill_with("+", batch)}{output.decode("UTF-8")}')
+                if veryverbose: debug_count_lines("gsutil.stderr", "just before read in attempt-2 block")
                 
                 # get success and exceptions from attempt-2
                 with open("gsutil.stderr", "r") as f:
@@ -261,24 +299,21 @@ def retrieve_data(gs_addresses: list):
                 attempt_2_successes = attempt_2_successes_and_exceptions[0]
                 attempt_2_exceptions = attempt_2_successes_and_exceptions[1]
                 global_successes.append(attempt_2_successes)
-            
+            if veryverbose: debug_count_lines("attempt2.tmp", "just before deletion")
             subprocess.run('rm attempt2.tmp', shell=True)
-            print("Finished checking for attempt 2.")
-            print(f"Attempted {len(exceptions)} downloads: {len(attempt_2_successes)} succeeded, {len(attempt_2_exceptions)} failed.")
-        
+
             # check for call-cache/ if any attempt-2/ downloads failed
             if len(attempt_2_exceptions) > 0:
-                print(f"Looking for {len(attempt_2_exceptions)} files in cacheCopy/ folders...")
+                print(f"{fill_with('    ', depth)}{fill_with('+', batch)}Looking for {len(attempt_2_exceptions)} files in cacheCopy/ folders...")
                 with open("cache_copy.tmp", "a") as f:
                     for failed_gs_uri in attempt_2_exceptions:
                         possible_output_if_call_cached = failed_gs_uri.removesuffix(args.file).removesuffix("attempt-2/") + "cacheCopy/" + args.file + "\n"
                         f.write(possible_output_if_call_cached)
                 # this call mixes a group A and a group B input variable -- but we'll allow that because it helps stop us from recursing infinitely
-                with subprocess.Popen(f'python3 pyoink.py --job_manager_arrays_file cache_copy.tmp --do_not_attempt2_on_failure', shell=True, stdout=subprocess.PIPE, stderr=subprocess.STDOUT) as recurse:
+                with subprocess.Popen(f'python3 pyoink.py --job_manager_arrays_file cache_copy.tmp --do_not_attempt2_on_failure -v', shell=True, stdout=subprocess.PIPE, stderr=subprocess.STDOUT) as recurse:
                     for output in recurse.stdout:
-                        print(f'--c-->{output.decode("UTF-8")}')
+                        print(f'{fill_with("    ", depth+1)}{fill_with("+", batch)}{output.decode("UTF-8")}')
                 subprocess.run('rm cache_copy.tmp', shell=True)
-                print("Finished checking for call cached outputs.")
 
         else:
             pass
@@ -287,6 +322,7 @@ def retrieve_data(gs_addresses: list):
 
 
 if __name__ == '__main__':
+    if verbose: "Welcome to pyoink!"
     if jm is not None:
         # option A
         # make sure the user isn't trying to use options A and B

--- a/pyoink_myco.py
+++ b/pyoink_myco.py
@@ -18,67 +18,60 @@ parser = argparse.ArgumentParser(prog="pyoink", formatter_class=argparse.Argumen
                                                 REQUIRES you have gsutil set up and authenticated.""")
 parser.add_argument('--submission_id', help="submission ID as it appears in Terra", required=True)
 parser.add_argument('--workflow_id', help="ID of workflow as it appears in Terra", required=True)
-parser.add_argument('--bucket', default="fc-d11c2e78-5175-400e-b517-6b070fad43b6")
+parser.add_argument('--bucket', default="fc-057366ca-c3a6-4847-86b9-82f941bda80c")
+parser.add_argument('--reportprefix', default="001")
 args = parser.parse_args()
 
 subprocess.run('touch gs_info.txt', shell=True)
 subprocess.run(f'echo \"bucket: {args.bucket}\nsubmission_id: {args.submission_id}\nworkflow_id: {args.workflow_id}\n\" >> gs_info.txt', shell=True)
 
 # this is done in order of the smallest downloads first
-#### download reports ####
-#subprocess.check_call(f'python3 pyoink.py --submission_id {args.submission_id} --bucket {args.bucket} --workflow_id {args.workflow_id} --file "pull_reports.txt" --task "cat_reports" --not_scattered', 
-#                        shell=True, stdout=sys.stdout, stderr=subprocess.STDOUT)
-#subprocess.run('mv downloaded_successfully.txt downloaded_successfully_pull.txt', shell=True)
-#subprocess.run('mv failed_to_download.txt failed_to_download_pull.txt', shell=True)
-#print("Finished pulling the SRA pull report file.")
 
-subprocess.check_call(f'python3 pyoink.py --submission_id {args.submission_id} --bucket {args.bucket} --workflow_id {args.workflow_id} --file "strain_reports.tsv" --task "cat_strains" --not_scattered', 
+#### download reports ####
+subprocess.check_call(f'python3 pyoink.py --submission_id {args.submission_id} --bucket {args.bucket} --workflow_id {args.workflow_id} --file "pull_reports.txt" --task "merge_reports" --not_scattered', 
                         shell=True, stdout=sys.stdout, stderr=subprocess.STDOUT)
-subprocess.run('mv downloaded_successfully.txt downloaded_successfully_strain.txt', shell=True)
-subprocess.run('mv failed_to_download.txt failed_to_download_strain.txt', shell=True)
+subprocess.run(f'mv pull_reports.txt {args.reportprefix}_pull_reports.txt', shell=True)
+print("Finished pulling the SRA pull report file.")
+
+subprocess.check_call(f'python3 pyoink.py --submission_id {args.submission_id} --bucket {args.bucket} --workflow_id {args.workflow_id} --file "strain_reports.tsv" --task "collate_bam_strains" --not_scattered', 
+                        shell=True, stdout=sys.stdout, stderr=subprocess.STDOUT)
+subprocess.run(f'mv strain_reports.tsv {args.reportprefix}_strain_reports.tsv', shell=True)
 print("Finished pulling the strain report file.")
 
-subprocess.check_call(f'python3 pyoink.py --submission_id {args.submission_id} --bucket {args.bucket} --workflow_id {args.workflow_id} --file "resistance_reports.tsv" --task "cat_resistance" --not_scattered', 
+subprocess.check_call(f'python3 pyoink.py --submission_id {args.submission_id} --bucket {args.bucket} --workflow_id {args.workflow_id} --file "resistance_reports.tsv" --task "collate_bam_resistance" --not_scattered', 
                         shell=True, stdout=sys.stdout, stderr=subprocess.STDOUT)
-subprocess.run('mv downloaded_successfully.txt downloaded_successfully_resistance.txt', shell=True)
-subprocess.run('mv failed_to_download.txt failed_to_download_resistance.txt', shell=True)
+subprocess.run(f'mv resistance_reports.tsv {args.reportprefix}_resistance_reports.tsv', shell=True)
 print("Finished pulling the resistance report file.")
 
 ### download diff reports ####
 subprocess.check_call(f'python3 pyoink.py --submission_id {args.submission_id} --bucket {args.bucket} --workflow_id {args.workflow_id} --file "*.report"', 
                         shell=True, stdout=sys.stdout, stderr=subprocess.STDOUT)
-subprocess.run('mv downloaded_successfully.txt downloaded_successfully_diffreports.txt', shell=True)
-subprocess.run('mv failed_to_download.txt failed_to_download_diffreports.txt', shell=True)
 print("Finished pulling the diff report files.")
 
 #### download tbprofiler jsons ####
-subprocess.check_call(f'python3 pyoink.py --submission_id {args.submission_id} --bucket {args.bucket} --workflow_id {args.workflow_id} --file "results/*.json" --task "profile"', 
+subprocess.check_call(f'python3 pyoink.py --submission_id {args.submission_id} --bucket {args.bucket} --workflow_id {args.workflow_id} --file "results/*.json" --task "profile_bam"', 
                         shell=True, stdout=sys.stdout, stderr=subprocess.STDOUT)
-subprocess.run('mv downloaded_successfully.txt downloaded_successfully_tbprf.txt', shell=True)
-subprocess.run('mv failed_to_download.txt failed_to_download_tbprf.txt', shell=True)
 print("Finished pulling TBProfiler JSONs.")
 
 #### download tbprofiler txts ####
-subprocess.check_call(f'python3 pyoink.py --submission_id {args.submission_id} --bucket {args.bucket} --workflow_id {args.workflow_id} --file "results/*.txt" --task "profile"', 
+subprocess.check_call(f'python3 pyoink.py --submission_id {args.submission_id} --bucket {args.bucket} --workflow_id {args.workflow_id} --file "results/*.txt" --task "profile_bam"', 
                         shell=True, stdout=sys.stdout, stderr=subprocess.STDOUT)
-subprocess.run('mv downloaded_successfully.txt downloaded_successfully_tbprftxt.txt', shell=True)
-subprocess.run('mv failed_to_download.txt failed_to_download_tbprftxt.txt', shell=True)
 print("Finished pulling TBProfiler text files.")
 
 #### download diffs ####
 subprocess.check_call(f'python3 pyoink.py --submission_id {args.submission_id} --bucket {args.bucket} --workflow_id {args.workflow_id} --file "*.diff"', 
                         shell=True, stdout=sys.stdout, stderr=subprocess.STDOUT)
-subprocess.run('mv downloaded_successfully.txt downloaded_successfully_diff.txt', shell=True)
 print("Finished pulling diffs.")
 
 #### download bedgraphs ####
 subprocess.check_call(f'python3 pyoink.py --submission_id {args.submission_id} --bucket {args.bucket} --workflow_id {args.workflow_id} --file "*.bedgraph"', 
                         shell=True, stdout=sys.stdout, stderr=subprocess.STDOUT)
-subprocess.run('mv downloaded_successfully.txt downloaded_successfully_bdgrph.txt', shell=True)
 print("Finished pulling bedgraphs.")
 
 #### download vcfs ####
-subprocess.check_call(f'python3 pyoink.py --submission_id {args.submission_id} --bucket {args.bucket} --workflow_id {args.workflow_id} --file "*.vcf" --task "varcall_with_array"', 
+subprocess.check_call(f'python3 pyoink.py --submission_id {args.submission_id} --bucket {args.bucket} --workflow_id {args.workflow_id} --file "*.vcf" --task "variant_calling"', 
                         shell=True, stdout=sys.stdout, stderr=subprocess.STDOUT)
-subprocess.run('mv downloaded_successfully.txt downloaded_successfully_vcf.txt', shell=True)
 print("Finished pulling vcfs.")
+
+subprocess.run('rm downloaded_successfully.txt', shell=True)
+subprocess.run('rm failed_to_download.txt', shell=True)

--- a/pyoink_myco.py
+++ b/pyoink_myco.py
@@ -1,6 +1,6 @@
 #!/usr/bin/python3
 
-# assumes files get copied to workdir and pyoink.py is in ../helper_scripts
+# assumes files get copied to workdir and pyoink.py is in workdir too
 # hardcoded for myco_sra
 
 import os 
@@ -18,7 +18,7 @@ parser = argparse.ArgumentParser(prog="pyoink", formatter_class=argparse.Argumen
                                                 REQUIRES you have gsutil set up and authenticated.""")
 parser.add_argument('--submission_id', help="submission ID as it appears in Terra", required=True)
 parser.add_argument('--workflow_id', help="ID of workflow as it appears in Terra", required=True)
-parser.add_argument('--bucket', default="fc-caa84e5a-8ef7-434e-af9c-feaf6366a042")
+parser.add_argument('--bucket', default="fc-d11c2e78-5175-400e-b517-6b070fad43b6")
 args = parser.parse_args()
 
 subprocess.run('touch gs_info.txt', shell=True)
@@ -26,19 +26,19 @@ subprocess.run(f'echo \"bucket: {args.bucket}\nsubmission_id: {args.submission_i
 
 # this is done in order of the smallest downloads first
 #### download reports ####
-subprocess.check_call(f'python3 pyoink.py --submission_id {args.submission_id} --bucket {args.bucket} --workflow_id {args.workflow_id} --file "pull_reports.txt" --task "cat_reports" --not_scattered', 
-                        shell=True, stdout=sys.stdout, stderr=subprocess.STDOUT)
-subprocess.run('mv downloaded_successfully.txt downloaded_successfully_pull.txt', shell=True)
-subprocess.run('mv failed_to_download.txt failed_to_download_pull.txt', shell=True)
-print("Finished pulling the SRA pull report file.")
+#subprocess.check_call(f'python3 pyoink.py --submission_id {args.submission_id} --bucket {args.bucket} --workflow_id {args.workflow_id} --file "pull_reports.txt" --task "cat_reports" --not_scattered', 
+#                        shell=True, stdout=sys.stdout, stderr=subprocess.STDOUT)
+#subprocess.run('mv downloaded_successfully.txt downloaded_successfully_pull.txt', shell=True)
+#subprocess.run('mv failed_to_download.txt failed_to_download_pull.txt', shell=True)
+#print("Finished pulling the SRA pull report file.")
 
-subprocess.check_call(f'python3 pyoink.py --submission_id {args.submission_id} --bucket {args.bucket} --workflow_id {args.workflow_id} --file "strain_reports.txt" --task "cat_strains" --not_scattered', 
+subprocess.check_call(f'python3 pyoink.py --submission_id {args.submission_id} --bucket {args.bucket} --workflow_id {args.workflow_id} --file "strain_reports.tsv" --task "cat_strains" --not_scattered', 
                         shell=True, stdout=sys.stdout, stderr=subprocess.STDOUT)
 subprocess.run('mv downloaded_successfully.txt downloaded_successfully_strain.txt', shell=True)
 subprocess.run('mv failed_to_download.txt failed_to_download_strain.txt', shell=True)
 print("Finished pulling the strain report file.")
 
-subprocess.check_call(f'python3 pyoink.py --submission_id {args.submission_id} --bucket {args.bucket} --workflow_id {args.workflow_id} --file "resistance_reports.txt" --task "cat_resistance" --not_scattered', 
+subprocess.check_call(f'python3 pyoink.py --submission_id {args.submission_id} --bucket {args.bucket} --workflow_id {args.workflow_id} --file "resistance_reports.tsv" --task "cat_resistance" --not_scattered', 
                         shell=True, stdout=sys.stdout, stderr=subprocess.STDOUT)
 subprocess.run('mv downloaded_successfully.txt downloaded_successfully_resistance.txt', shell=True)
 subprocess.run('mv failed_to_download.txt failed_to_download_resistance.txt', shell=True)
@@ -66,7 +66,7 @@ subprocess.run('mv failed_to_download.txt failed_to_download_tbprftxt.txt', shel
 print("Finished pulling TBProfiler text files.")
 
 #### download diffs ####
-subprocess.check_call(f'python3 pyoink.py --submission_id {args.submission_id} --bucket {args.bucket} --workflow_id {args.workflow_id}', 
+subprocess.check_call(f'python3 pyoink.py --submission_id {args.submission_id} --bucket {args.bucket} --workflow_id {args.workflow_id} --file "*.diff"', 
                         shell=True, stdout=sys.stdout, stderr=subprocess.STDOUT)
 subprocess.run('mv downloaded_successfully.txt downloaded_successfully_diff.txt', shell=True)
 print("Finished pulling diffs.")


### PR DESCRIPTION
You could previously kind of do this by running the script twice with and without --cacheCopy, but both runs would try to download every possible file and that's just wasteful.

Now, only shards that failed both standard and attempt-2 (once-preempted) downloads will be valid for cacheCopy download, massively reducing the amount of `gsutil ls` and `gsutil cp` commands necessary.